### PR TITLE
feat: Добавить настраиваемые правила, статистику и полное редактирова…

### DIFF
--- a/rules/substring_check.py
+++ b/rules/substring_check.py
@@ -1,0 +1,42 @@
+import re
+
+RULE_NAME = "Проверка на подстроку"
+RULE_DESC = "Проверяет, содержит ли значение указанную подстроку или, наоборот, не содержит ее."
+IS_CONFIGURABLE = True
+
+def format_name(params):
+    """Formats the rule name with its parameters for display."""
+    mode = params.get("mode", "contains")
+    value = params.get("value", "")
+    mode_text = "содержит" if mode == "contains" else "не содержит"
+    return f"{RULE_NAME} ({mode_text}: '{value}')"
+
+def validate(value, params=None):
+    """
+    Checks if a string contains or does not contain a specific substring.
+    Non-string values are ignored.
+    """
+    if not isinstance(value, str):
+        return True # This rule only applies to strings.
+
+    if not params:
+        # If no params are provided, we can't perform a check.
+        # Depending on desired strictness, this could be True or False.
+        # Let's consider it True to not throw unnecessary errors.
+        return True
+
+    mode = params.get("mode", "contains") # 'contains' or 'not_contains'
+    substring = params.get("value", "")
+
+    if not substring:
+        # If substring is empty, all strings contain it.
+        # This is usually not the desired behavior, so we can treat it as a pass.
+        return True
+
+    if mode == "contains":
+        return substring in value
+    elif mode == "not_contains":
+        return substring not in value
+    else:
+        # Invalid mode, treat as a pass
+        return True

--- a/static/edit_template.html
+++ b/static/edit_template.html
@@ -36,6 +36,20 @@
     <!-- Notification Toast -->
     <div id="notification-toast" class="toast"></div>
 
+    <!-- Modal for configuring a rule -->
+    <div id="rule-config-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <h2 id="rule-config-title">Настроить правило</h2>
+            <div id="rule-config-form">
+                <!-- Dynamic form fields will be injected here -->
+            </div>
+            <div class="modal-actions">
+                <button id="cancel-rule-config-btn" class="secondary-button">Отмена</button>
+                <button id="confirm-rule-config-btn" class="action-button">Применить</button>
+            </div>
+        </div>
+    </div>
+
     <script src="/static/edit_template.js"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -70,6 +70,20 @@
     <!-- Notification Toast -->
     <div id="notification-toast" class="toast"></div>
 
+    <!-- Modal for configuring a rule -->
+    <div id="rule-config-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <h2 id="rule-config-title">Настроить правило</h2>
+            <div id="rule-config-form">
+                <!-- Dynamic form fields will be injected here -->
+            </div>
+            <div class="modal-actions">
+                <button id="cancel-rule-config-btn" class="secondary-button">Отмена</button>
+                <button id="confirm-rule-config-btn" class="action-button">Применить</button>
+            </div>
+        </div>
+    </div>
+
     <script src="/static/script.js"></script>
 </body>
 </html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -462,6 +462,28 @@ p {
     gap: 10px;
 }
 
+#rule-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    text-align: left;
+    margin-bottom: 20px;
+}
+
+#rule-config-form label {
+    font-weight: bold;
+    color: #34495e;
+}
+
+#rule-config-form select,
+#rule-config-form input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-sizing: border-box;
+}
+
 #validation-results-container {
     margin-top: 30px;
     text-align: left;


### PR DESCRIPTION
…ние шаблонов

Это крупное обновление, которое добавляет в приложение три мощные новые функции, значительно расширяя его возможности и гибкость.

Ключевые изменения:

1.  **Полноценное редактирование шаблонов:**
    - Реализована возможность изменять не только имя шаблона, но и полный набор правил для каждой колонки через специальную страницу редактирования (`/templates/edit/{id}`).
    - Бэкенд (`PUT /api/templates/{id}`) обновлен для приема и сохранения полного объекта шаблона.

2.  **Настраиваемые правила:**
    - Создана инфраструктура для правил, которые требуют пользовательской настройки.
    - Бэкенд теперь может обрабатывать правила с параметрами (например, `{"id": "rule_id", "params": {...}}`).
    - В качестве примера добавлено новое правило `substring_check`, которое может проверять наличие или отсутствие подстроки, заданной пользователем.
    - Интерфейс обновлен для поддержки таких правил: при их выборе появляется модальное окно для ввода параметров.

3.  **Расширенная статистика в результатах:**
    - В сводную таблицу с результатами валидации добавлена новая колонка "Процент ошибок".
    - Этот процент рассчитывается относительно общего количества строк в файле, что дает пользователю более полное представление о качестве данных.
    - Бэкенд (`/api/validate`) теперь возвращает общее количество строк вместе со списком ошибок.

4.  **Прочие исправления и улучшения:**
    - Исправлена критическая ошибка в логике валидации, из-за которой правило "Не пустое" не работало корректно.
    - Восстановлен полный, стандартный `.gitignore` для Python-проектов.
    - Устранены несоответствия и мертвый код в JavaScript, связанные с предыдущими итерациями разработки.