### PR TITLE
feat(debug): Добавить отладочный шаблон и логирование для страницы ре…

### DIFF
--- a/main.py
+++ b/main.py
@@ -80,12 +80,31 @@ def validate(value):
             f.write(content.strip())
         print("Created default rule file: starts_with_capital.py")
 
+def setup_debug_template():
+    """Ensures a debug template with a known ID exists for testing."""
+    DEBUG_TEMPLATE_ID = "debug-template-123"
+    templates = read_templates()
+    if not any(t.id == DEBUG_TEMPLATE_ID for t in templates):
+        debug_template = Template(
+            id=DEBUG_TEMPLATE_ID,
+            name="!!! ОТЛАДОЧНЫЙ ШАБЛОН !!!",
+            columns=["Имя", "Город"],
+            rules={
+                "Имя": [{"id": "not_empty", "params": None}],
+                "Город": [{"id": "starts_with_capital", "params": None}]
+            }
+        )
+        templates.append(debug_template)
+        write_templates(templates)
+        print(f"Created debug template with ID: {DEBUG_TEMPLATE_ID}")
+
 @app.on_event("startup")
 async def startup_event():
     """
     On application startup, set up directories and load rules.
     """
     setup_default_rule()
+    setup_debug_template() # Add this call
     load_rules()
 
 # --- Static Files & HTML Routes ---

--- a/static/edit_template.html
+++ b/static/edit_template.html
@@ -32,10 +32,10 @@
         <div id="loading" class="loading-spinner"></div>
         <div id="error-container" class="error-container"></div>
 
-        <!-- Temporary Debug Output -->
-        <div id="debug-output" style="margin-top: 20px; background-color: #eee; padding: 10px; border: 1px solid #ccc; display: none;">
-            <h3>Отладочная информация:</h3>
-            <pre></pre>
+        <!-- Permanent Debug Output -->
+        <div id="debug-log-container" style="margin-top: 20px; border: 1px solid #ccc; background: #f5f5f5; max-height: 200px; overflow-y: auto;">
+            <h4 style="margin: 5px; padding: 5px; border-bottom: 1px solid #ccc;">Отладочный лог:</h4>
+            <ul id="debug-log-list" style="list-style-type: none; margin: 0; padding: 5px; font-family: monospace; font-size: 12px;"></ul>
         </div>
     </div>
 


### PR DESCRIPTION
…дактирования

Это ВРЕМЕННЫЙ коммит, предназначенный исключительно для отладки проблемы с рендерингом на странице редактирования шаблонов. Не вливать в основную ветку.

Ключевые изменения:
- **Автоматическое создание отладочного шаблона:** В `main.py` добавлена логика, которая при запуске сервера создает "дежурный" шаблон с фиксированным ID (`debug-template-123`). Это гарантирует, что у нас всегда будет общий шаблон для тестирования.
- **Детальное логирование:** В `edit_template.js` добавлена функция `log()`, которая выводит в специальный блок на странице пошаговый отчет о выполнении скрипта. Это поможет нам точно определить, на каком этапе происходит сбой.
- **Обновление HTML:** В `edit_template.html` добавлен `div` для отображения отладочного лога.