### PR TITLE
fix: Исправить редактор шаблонов и связанные ошибки

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -268,6 +268,16 @@ p {
     background-color: #c0392b;
 }
 
+.clickable-rule {
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+}
+
+.clickable-rule:hover {
+    color: #2980b9;
+}
+
 .template-body p {
     margin: 0 0 10px 0;
 }


### PR DESCRIPTION
Этот коммит исправляет критическую ошибку с рендерингом редактора шаблонов и вносит другие улучшения, основанные на последнем ревью.

Ключевые исправления и улучшения:

1.  **Исправлен редактор шаблонов:**
    - Логика рендеринга в `edit_template.js` была полностью переписана с использованием `createElement` вместо `innerHTML`, чтобы избежать проблем с асинхронной обработкой DOM и гарантировать отображение интерфейса.
    - Добавлена возможность редактировать параметры уже примененных правил по клику на тег с правилом.

2.  **Исправлена логика правила "Проверка на подстроку":**
    - Логика правила `substring_check` была инвертирована, чтобы соответствовать ожиданиям: `mode: 'contains'` теперь считает ошибкой наличие подстроки (работает как стоп-слово).

3.  **Исправлено отображение правил:**
    - Устранена ошибка `[object Object]` на странице со списком шаблонов. Теперь там корректно отображаются полные имена и параметры всех правил.

4.  **Добавлена проверка на дублирование правил:**
    - В интерфейс добавлена логика, которая не позволяет пользователю добавить одно и то же правило к одной колонке дважды.

5.  **Переименовано правило "Начинается с заглавной"** на "Не начинается с заглавной" для большей ясности.