### PR TITLE
refactor: Переход на APIRouter для исправления ошибки 404

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,13 +10,15 @@ import pandas as pd
 import io
 import json
 
-from fastapi import FastAPI, File, UploadFile, HTTPException
+from fastapi import FastAPI, APIRouter, File, UploadFile, HTTPException
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
 # --- Globals & Setup ---
 app = FastAPI()
+api_router = APIRouter() # Use a router for all API endpoints
+
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "static"
 RULES_DIR = BASE_DIR / "rules"
@@ -70,63 +72,48 @@ class Template(BaseModel):
 class MatchRequest(BaseModel):
     columns: List[str]
 
-# --- Project Helper Functions ---
+# --- Helper Functions ---
 
 def read_project(project_id: str) -> Optional[Project]:
     config_path = PROJECTS_DIR / project_id / "project.json"
-    if not config_path.exists():
-        return None
+    if not config_path.exists(): return None
     try:
         return Project(**json.loads(config_path.read_text(encoding="utf-8")))
-    except (json.JSONDecodeError, TypeError, ValueError) as e:
-        print(f"Error reading or validating project {project_id}: {e}")
+    except Exception as e:
+        print(f"Error reading project {project_id}: {e}")
         return None
 
 def write_project(project_id: str, project_data: Project):
     config_path = PROJECTS_DIR / project_id / "project.json"
     project_data.updated_at = datetime.datetime.utcnow().isoformat()
-    with open(config_path, "w", encoding="utf-8") as f:
-        json.dump(project_data.model_dump(), f, indent=2, ensure_ascii=False)
-
-# --- Template Helper Functions ---
+    config_path.write_text(project_data.model_dump_json(indent=2), encoding="utf-8")
 
 def read_templates() -> List[Template]:
     if not TEMPLATES_FILE.exists(): return []
     try:
         raw_data = TEMPLATES_FILE.read_text(encoding="utf-8")
         if not raw_data.strip(): return []
-        templates_data = json.loads(raw_data)
-    except (json.JSONDecodeError, FileNotFoundError):
-        return []
-
-    # Migration logic can be added here if needed in the future
-    try:
-        return [Template(**t) for t in templates_data]
+        return [Template(**t) for t in json.loads(raw_data)]
     except Exception as e:
-        print(f"Pydantic validation failed for templates: {e}")
+        print(f"Error reading templates: {e}")
         return []
 
 def write_templates(templates: List[Template]):
     with open(TEMPLATES_FILE, "w", encoding="utf-8") as f:
-        json_data = [t.model_dump() for t in templates]
-        json.dump(json_data, f, indent=2, ensure_ascii=False)
-
-# --- Rule Discovery ---
+        json.dump([t.model_dump() for t in templates], f, indent=2, ensure_ascii=False)
 
 def load_rules():
     RULE_REGISTRY.clear()
     for filename in os.listdir(RULES_DIR):
         if filename.endswith(".py") and filename != "__init__.py":
-            rule_id = filename[:-3]
-            module_path = RULES_DIR / filename
             try:
-                spec = importlib.util.spec_from_file_location(rule_id, module_path)
+                spec = importlib.util.spec_from_file_location(filename[:-3], RULES_DIR / filename)
                 if spec and spec.loader:
                     module = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(module)
                     if hasattr(module, "validate") and hasattr(module, "RULE_NAME"):
-                        RULE_REGISTRY[rule_id] = {
-                            "id": rule_id,
+                        RULE_REGISTRY[filename[:-3]] = {
+                            "id": filename[:-3],
                             "name": module.RULE_NAME,
                             "description": getattr(module, "RULE_DESC", ""),
                             "validator": module.validate,
@@ -138,75 +125,60 @@ def load_rules():
 
 # --- API Endpoints ---
 
-# --- Project Management ---
-@app.post("/api/projects", status_code=201, response_model=Project)
+@api_router.get("/api/projects")
+async def get_projects():
+    projects = []
+    for project_dir in PROJECTS_DIR.iterdir():
+        if project_dir.is_dir():
+            project = read_project(project_dir.name)
+            if project:
+                project_dict = project.model_dump()
+                total_size = sum(f.stat().st_size for f in project_dir.glob('**/*') if f.is_file())
+                project_dict["size_kb"] = round(total_size / 1024, 2)
+                projects.append(project_dict)
+    projects.sort(key=lambda p: p['updated_at'], reverse=True)
+    return projects
+
+@api_router.post("/api/projects", status_code=201, response_model=Project)
 async def create_project(project_data: ProjectCreateRequest):
     project_id = str(uuid.uuid4())
-    project_dir = PROJECTS_DIR / project_id
-    project_dir.mkdir(exist_ok=True)
+    (PROJECTS_DIR / project_id).mkdir(exist_ok=True)
     now = datetime.datetime.utcnow().isoformat()
-    project_info = Project(
-        id=project_id, name=project_data.name, description=project_data.description,
-        created_at=now, updated_at=now,
-    )
-    write_project(project_id, project_info)
-    return project_info
-
-@app.get("/api/projects")
-async def get_projects():
-    print("--- DEBUG: Запрос к /api/projects получен ---")
-    # Временно возвращаем жестко закодированный список для отладки
-    # Это поможет понять, связана ли ошибка с логикой чтения проектов или с самим роутингом
-    test_project = {
-        "id": "test-id-1",
-        "name": "Тестовый проект (из кода)",
-        "description": "Если вы видите это, значит роутинг работает.",
-        "created_at": datetime.datetime.utcnow().isoformat(),
-        "updated_at": datetime.datetime.utcnow().isoformat(),
-        "files": [],
-        "rules": {}
-    }
-    print(f"--- DEBUG: Отправка тестового проекта: {test_project} ---")
-    return [test_project]
-
-@app.get("/api/projects/{project_id}", response_model=Project)
-async def get_project_details(project_id: str):
-    project = read_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    project = Project(id=project_id, name=project_data.name, description=project_data.description, created_at=now, updated_at=now)
+    write_project(project_id, project)
     return project
 
-@app.put("/api/projects/{project_id}", response_model=Project)
+@api_router.get("/api/projects/{project_id}", response_model=Project)
+async def get_project_details(project_id: str):
+    project = read_project(project_id)
+    if not project: raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+@api_router.put("/api/projects/{project_id}", response_model=Project)
 async def update_project(project_id: str, project_update: ProjectUpdateRequest):
     project = read_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    if not project: raise HTTPException(status_code=404, detail="Project not found")
     project.name = project_update.name
     project.description = project_update.description
     write_project(project_id, project)
     return project
 
-@app.delete("/api/projects/{project_id}", status_code=204)
+@api_router.delete("/api/projects/{project_id}", status_code=204)
 async def delete_project(project_id: str):
     project_dir = PROJECTS_DIR / project_id
-    if not project_dir.is_dir():
-        raise HTTPException(status_code=404, detail="Project not found")
+    if not project_dir.is_dir(): raise HTTPException(status_code=404, detail="Project not found")
     shutil.rmtree(project_dir)
-    return
 
-# --- Project File & Validation Operations ---
-@app.post("/api/projects/{project_id}/upload")
+@api_router.post("/api/projects/{project_id}/upload")
 async def upload_file_to_project(project_id: str, file: UploadFile = File(...)):
     project = read_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
+    if not project: raise HTTPException(status_code=404, detail="Project not found")
     if not file.filename or not (file.filename.endswith('.xlsx') or file.filename.endswith('.xls')):
         raise HTTPException(status_code=400, detail="Invalid file type")
 
     project_files_dir = PROJECTS_DIR / project_id / "files"
     project_files_dir.mkdir(exist_ok=True)
 
-    # Remove old file if it exists to enforce one-file-per-project
     if project.files:
         for old_file in project.files:
             old_file_path = project_files_dir / old_file['saved_name']
@@ -222,43 +194,37 @@ async def upload_file_to_project(project_id: str, file: UploadFile = File(...)):
         "sheets": pd.ExcelFile(io.BytesIO(contents)).sheet_names
     }
     project.files = [file_info]
-    project.rules = {}  # Reset rules on new file upload
+    project.rules = {}
     write_project(project_id, project)
     return file_info
 
-@app.post("/api/projects/{project_id}/select-sheet")
+@api_router.post("/api/projects/{project_id}/select-sheet")
 async def select_project_sheet(project_id: str, request: SheetSelectRequest):
     project = read_project(project_id)
-    if not project or not project.files:
-        raise HTTPException(status_code=404, detail="Project or file not found")
+    if not project or not project.files: raise HTTPException(status_code=404, detail="Project or file not found")
 
     file_info = next((f for f in project.files if f['id'] == request.fileId), None)
-    if not file_info:
-        raise HTTPException(status_code=404, detail="File ID not found in project")
+    if not file_info: raise HTTPException(status_code=404, detail="File ID not found in project")
 
     file_path = PROJECTS_DIR / project_id / "files" / file_info['saved_name']
-    if not file_path.exists():
-        raise HTTPException(status_code=404, detail="File data not found on disk")
+    if not file_path.exists(): raise HTTPException(status_code=404, detail="File data not found on disk")
 
     df = pd.read_excel(file_path, sheet_name=request.sheetName)
     return {"columns": df.columns.tolist()}
 
-@app.post("/api/projects/{project_id}/validate")
+@api_router.post("/api/projects/{project_id}/validate")
 async def validate_project_data(project_id: str, request: ValidationRequest):
     project = read_project(project_id)
-    if not project or not project.files:
-        raise HTTPException(status_code=404, detail="Project or file not found")
+    if not project or not project.files: raise HTTPException(status_code=404, detail="Project or file not found")
 
     project.rules = request.rules
     write_project(project_id, project)
 
     file_info = next((f for f in project.files if f['id'] == request.fileId), None)
-    if not file_info:
-        raise HTTPException(status_code=404, detail="File not found in project")
+    if not file_info: raise HTTPException(status_code=404, detail="File not found in project")
 
     file_path = PROJECTS_DIR / project_id / "files" / file_info['saved_name']
-    if not file_path.exists():
-        raise HTTPException(status_code=404, detail="File data not found on disk")
+    if not file_path.exists(): raise HTTPException(status_code=404, detail="File data not found on disk")
 
     df = pd.read_excel(file_path, sheet_name=request.sheetName)
     errors = []
@@ -279,16 +245,15 @@ async def validate_project_data(project_id: str, request: ValidationRequest):
 
     return {"total_rows": len(df), "error_rows_count": len({e["row"] for e in errors}), "errors": errors}
 
-# --- Rule & Template Library ---
-@app.get("/api/rules")
+@api_router.get("/api/rules")
 async def get_all_rules():
     return [{"id": data["id"], "name": data["name"], "description": data["description"], "is_configurable": data["is_configurable"]} for data in RULE_REGISTRY.values()]
 
-@app.get("/api/templates", response_model=List[Template])
+@api_router.get("/api/templates", response_model=List[Template])
 async def get_templates():
     return read_templates()
 
-@app.post("/api/templates", response_model=Template, status_code=201)
+@api_router.post("/api/templates", response_model=Template, status_code=201)
 async def create_template(template: Template):
     templates = read_templates()
     if any(t.name.lower() == template.name.lower() for t in templates):
@@ -297,12 +262,11 @@ async def create_template(template: Template):
     write_templates(templates)
     return template
 
-@app.put("/api/templates/{template_id}", response_model=Template)
+@api_router.put("/api/templates/{template_id}", response_model=Template)
 async def update_template(template_id: str, template_update: Template):
     templates = read_templates()
     template_index = next((i for i, t in enumerate(templates) if t.id == template_id), -1)
-    if template_index == -1:
-        raise HTTPException(status_code=404, detail="Template not found.")
+    if template_index == -1: raise HTTPException(status_code=404, detail="Template not found.")
     if any(t.name.lower() == template_update.name.lower() and t.id != template_id for t in templates):
         raise HTTPException(status_code=400, detail=f"Template name '{template_update.name}' already exists.")
     template_update.id = template_id
@@ -310,21 +274,22 @@ async def update_template(template_id: str, template_update: Template):
     write_templates(templates)
     return template_update
 
-@app.delete("/api/templates/{template_id}", status_code=204)
+@api_router.delete("/api/templates/{template_id}", status_code=204)
 async def delete_template(template_id: str):
     templates = read_templates()
     if not any(t.id == template_id for t in templates):
         raise HTTPException(status_code=404, detail="Template not found.")
     write_templates([t for t in templates if t.id != template_id])
-    return
 
-@app.post("/api/templates/find-matches", response_model=List[Template])
+@api_router.post("/api/templates/find-matches", response_model=List[Template])
 async def find_matching_templates(request: MatchRequest):
     templates = read_templates()
     request_columns_set = set(request.columns)
     return [t for t in templates if set(t.columns) == request_columns_set]
 
-# --- HTML Serving ---
+# --- App Setup ---
+
+app.include_router(api_router)
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 @app.get("/")
@@ -349,7 +314,6 @@ async def read_templates_page():
 async def read_edit_template_page(template_id: str):
     return FileResponse(STATIC_DIR / "edit_template.html")
 
-# --- Startup ---
 def setup_default_rule():
     default_rule_path = RULES_DIR / "starts_with_capital.py"
     if not default_rule_path.exists():

--- a/static/script.js
+++ b/static/script.js
@@ -245,5 +245,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- 5. Initial Load ---
-    fetchAndRenderProjects();
+    try {
+        console.log("Attempting to fetch and render projects...");
+        fetchAndRenderProjects();
+        console.log("Initial fetch call succeeded.");
+    } catch (e) {
+        console.error("Critical error on initial load:", e);
+        alert("Критическая ошибка при загрузке скрипта: " + e.message);
+    }
 });
+console.log("DQMaster script.js loaded successfully.");


### PR DESCRIPTION
Для решения постоянной и необъяснимой ошибки 404 Not Found на API-эндпоинтах, вся логика API была перенесена в `APIRouter`.

Ключевые изменения:
- **Внедрение APIRouter:** Все эндпоинты, начинающиеся с `/api`, теперь регистрируются через экземпляр `APIRouter`, который затем подключается к основному приложению `FastAPI`. Это стандартная практика для организации сложных приложений, которая повышает надежность роутинга.
- **Структурирование кода:** Файл `main.py` был полностью переформатирован для ясности. Модели, вспомогательные функции и эндпоинты сгруппированы в логические блоки.

Это архитектурное изменение направлено на устранение корневой причины проблемы с обнаружением маршрутов сервером и должно обеспечить стабильную работу API.