### PR TITLE
fix: Добавлена отладка 404 и восстановлены ссылки в UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import pandas as pd
 import io
 import json
 
-from fastapi import FastAPI, APIRouter, File, UploadFile, HTTPException
+from fastapi import FastAPI, APIRouter, File, UploadFile, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
@@ -317,6 +317,18 @@ async def read_templates_page():
 @app.get("/templates/edit/{template_id}")
 async def read_edit_template_page(template_id: str):
     return FileResponse(STATIC_DIR / "edit_template.html")
+
+# This is a catch-all for debugging 404s. It should be the last route.
+@app.post("/{full_path:path}")
+async def catch_all_post(request: Request, full_path: str):
+    print(f"--- DEBUG: Необработанный POST-запрос получен ---")
+    print(f"Полный путь: /{full_path}")
+    print(f"Метод: {request.method}")
+    print(f"Заголовки: {request.headers}")
+    body = await request.body()
+    print(f"Тело запроса: {body.decode()}")
+    print("-------------------------------------------------")
+    raise HTTPException(status_code=404, detail=f"Эндпоинт POST /{full_path} не найден.")
 
 def setup_default_rule():
     default_rule_path = RULES_DIR / "starts_with_capital.py"

--- a/static/index.html
+++ b/static/index.html
@@ -11,7 +11,8 @@
         <header class="page-header">
             <h1>📁 Мои проекты</h1>
             <div class="header-actions">
-                <a href="/templates" class="nav-link">Библиотека правил</a>
+                <a href="/rules" class="nav-link">Библиотека правил</a>
+                <a href="/templates" class="nav-link">Шаблоны</a>
                 <button id="create-project-btn" class="action-button">Создать проект</button>
             </div>
         </header>


### PR DESCRIPTION
Этот коммит вносит два ключевых исправления для дальнейшей отладки и восстановления функциональности.

1.  **Отладка 404 при создании проекта:**
    - В `main.py` добавлен универсальный маршрут-ловушка (`catch-all`) для `POST` запросов.
    - Если запрос на создание проекта не доходит до нужного эндпоинта, этот маршрут перехватит его и выведет в консоль сервера подробную информацию: запрашиваемый URL, заголовки и тело запроса.
    - Это позволит точно диагностировать, почему сервер отвечает ошибкой `404 Not Found`.

2.  **Восстановление навигации:**
    - В `static/index.html` восстановлены ссылки на "Библиотеку правил" (`/rules`) и "Шаблоны" (`/templates`), которые были случайно удалены в ходе рефакторинга.
    - Это возвращает пользователю доступ к важным разделам приложения.