### PR TITLE
debug: Добавлен вывод всех маршрутов при старте для отладки 404

### DIFF
--- a/main.py
+++ b/main.py
@@ -379,3 +379,10 @@ async def startup_event():
 
     setup_default_rule()
     load_rules()
+
+    # --- DEBUG: Print all registered routes ---
+    print("\n--- Registered Routes ---")
+    for route in app.routes:
+        if hasattr(route, "methods"):
+            print(f"Path: {route.path}, Methods: {route.methods}")
+    print("-------------------------\n")


### PR DESCRIPTION
Для окончательной диагностики постоянной ошибки `404 Not Found` при создании проекта, в событие `startup` добавлена функция, которая итерирует по `app.routes` и выводит в консоль все зарегистрированные пути и их методы.

Это позволит нам со 100% уверенностью определить, видит ли FastAPI эндпоинт `POST /api/projects` в момент запуска. Это изменение является чисто диагностическим и направлено на решение корневой причины проблемы с роутингом.