### PR TITLE
debug: Добавлена отладка на клиенте и сервере для решения 404

### DIFF
--- a/main.py
+++ b/main.py
@@ -151,9 +151,9 @@ async def get_projects():
     projects.sort(key=lambda p: p.updated_at, reverse=True)
     return projects
 
-# NEW, RENAMED ENDPOINT FOR DEBUGGING
-@app.post("/api/create_new_project_test", status_code=201, response_model=Project)
-async def create_project_test(project_data: ProjectCreateRequest):
+@app.post("/api/projects", status_code=201, response_model=Project)
+async def create_project(project_data: ProjectCreateRequest):
+    print(f"--- SERVER: Запрос на создание проекта получен. Данные: {project_data.model_dump_json()} ---")
     project_id = str(uuid.uuid4())
     (PROJECTS_DIR / project_id).mkdir(exist_ok=True)
     now = datetime.datetime.utcnow().isoformat()

--- a/static/script.js
+++ b/static/script.js
@@ -112,10 +112,15 @@ document.addEventListener('DOMContentLoaded', () => {
         confirmCreateProjectBtn.disabled = true;
 
         try {
-            const response = await fetch('/api/create_new_project_test', {
+            const payload = { name, description };
+            console.log("--- Отправка запроса на создание проекта ---");
+            console.log("URL:", '/api/projects');
+            console.log("Тело запроса (payload):", JSON.stringify(payload));
+
+            const response = await fetch('/api/projects', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name, description }),
+                body: JSON.stringify(payload),
             });
 
             if (!response.ok) {


### PR DESCRIPTION
Это финальная попытка диагностировать постоянную ошибку 404 Not Found при создании проекта. Изменения внесены как на клиентскую, так и на серверную сторону для получения полной картины происходящего.

Изменения:
1.  **Клиент (`static/script.js`):**
    - В функцию `handleCreateProject` прямо перед `fetch` запросом добавлен `console.log`.
    - Он выводит в консоль браузера точный URL и тело запроса, который отправляется на сервер.

2.  **Сервер (`main.py`):**
    - Файл очищен от предыдущих отладочных правок.
    - В самое начало функции `create_project` добавлен единственный `print`, который сообщает о том, что запрос успешно дошел до нужного обработчика.

Этот подход "пинга" с двух сторон позволит нам точно определить, на каком этапе теряется запрос, и окончательно решить проблему.